### PR TITLE
Issue 002 - Test case required for find_lan_access_rejected

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = router_log_analyzer

--- a/tests/test_find_actions.py
+++ b/tests/test_find_actions.py
@@ -1,13 +1,37 @@
 """Tests to cover the find actions functionality"""
 
-# import pytest
+import pytest
 
 import router_log_analyzer.find_actions
 
 
-def test_router_log_analyzer_find_actions_find_lan_access_rejected():
+@pytest.mark.parametrize(
+    "entries, entry_date, number_of_matches_expected",
+    [
+        (["no match to be found"], "02/20/2025", 0),  # no matches case
+        (
+            # 1 match case
+            ["[WLAN access rejected: incorrect security] from MAC 55:CC:EA:DF:DD:AA"],
+            "02/20/2025",
+            1,
+        ),
+        (
+            # 2 match case
+            [
+                "[WLAN access rejected: incorrect security] from MAC 55:CC:EA:DF:DD:AA",
+                "No Match in this string",
+                "[WLAN access rejected: incorrect security] from MAC 11:CC:EA:11:00:AA",
+            ],
+            "02/20/2025",
+            2,
+        ),
+    ],
+)
+def test_router_log_analyzer_find_actions_find_lan_access_rejected_find_none(
+    entries, entry_date, number_of_matches_expected
+):
     returned_match_object = router_log_analyzer.find_actions.find_lan_access_rejected(
-        "todo", "02/20/2025"
+        entries, entry_date
     )
 
-    assert False
+    assert len(returned_match_object) == number_of_matches_expected

--- a/tests/test_find_actions.py
+++ b/tests/test_find_actions.py
@@ -1,0 +1,13 @@
+"""Tests to cover the find actions functionality"""
+
+# import pytest
+
+import router_log_analyzer.find_actions
+
+
+def test_router_log_analyzer_find_actions_find_lan_access_rejected():
+    returned_match_object = router_log_analyzer.find_actions.find_lan_access_rejected(
+        "todo", "02/20/2025"
+    )
+
+    assert False


### PR DESCRIPTION
This PR creates a few testcases for the find_lan_access_rejected functionality.  Check for zero, one, and two matches.