### PR TITLE
Issue 004 - Test case required for find_unknown_macs

### DIFF
--- a/tests/test_find_actions.py
+++ b/tests/test_find_actions.py
@@ -27,10 +27,46 @@ import router_log_analyzer.find_actions
         ),
     ],
 )
-def test_router_log_analyzer_find_actions_find_lan_access_rejected_find_none(
+def test_router_log_analyzer_find_actions_find_lan_access_rejected_find(
     entries, entry_date, number_of_matches_expected
 ):
     returned_match_object = router_log_analyzer.find_actions.find_lan_access_rejected(
+        entries, entry_date
+    )
+
+    assert len(returned_match_object) == number_of_matches_expected
+
+
+@pytest.mark.parametrize(
+    "entries, entry_date, number_of_matches_expected",
+    [
+        (
+            ["no match to be found"],
+            "Sunday, Oct 27,2024 12:14:11",
+            0,
+        ),  # no matches case
+        (
+            # 1 match case
+            ["[DHCP IP: (10.0.0.11)] to MAC address AA:66:FF:00:99:72"],
+            "Sunday, Oct 27,2024 12:14:11",
+            1,
+        ),
+        (
+            # 2 match case
+            [
+                "[DHCP IP: (10.0.0.11)] to MAC address AA:66:FF:00:99:72",
+                "No Match in this string",
+                "[DHCP IP: (10.0.0.23)] to MAC address FF:66:FF:00:FF:72",
+            ],
+            "Sunday, Oct 27,2024 12:14:15",
+            2,
+        ),
+    ],
+)
+def test_router_log_analyzer_find_actions_find_unknown_macs(
+    entries, entry_date, number_of_matches_expected
+):
+    returned_match_object = router_log_analyzer.find_actions.find_unknown_macs(
         entries, entry_date
     )
 


### PR DESCRIPTION
Create a test case that checks for zero, one, and two matches.

This implements #4 