### PR TITLE
Issue 001 - End of run Summary only shows one entry per log file when more than one match occurs

### DIFF
--- a/router_log_analyzer/find_actions.py
+++ b/router_log_analyzer/find_actions.py
@@ -29,17 +29,22 @@ def find_lan_access_rejected(entries, entry_date):
     print("\n\tHere is a list MAC addresses that were rejected access...")
     if len(mac_addresses_wlan_access_rejected) == 0:
         print("\t\tNone")
-    for address in mac_addresses_wlan_access_rejected:
+    for match_sequence_number, address in enumerate(mac_addresses_wlan_access_rejected):
+        sequenced_entry_date = "".join([entry_date, "-", str(match_sequence_number)])
         if address in recognizedmacs.recognizedmacaddresses:
             print(
                 f"\t\tRejected - Recognized "
                 f"{address} as "
                 f"{str(recognizedmacs.recognizedmacaddresses.get(address))}"
             )
-            wlan_accesses_rejected.update({entry_date: (address, "recognized")})
+            wlan_accesses_rejected.update(
+                {sequenced_entry_date: (address, "recognized")}
+            )
         else:
             print(f"\t\t!! Rejected - Did not recognize {address}")
-            wlan_accesses_rejected.update({entry_date: (address, "not recognized")})
+            wlan_accesses_rejected.update(
+                {sequenced_entry_date: (address, "not recognized")}
+            )
 
     return wlan_accesses_rejected
 
@@ -60,9 +65,12 @@ def find_site_blocked(entries, entry_date):
     if len(list_site_blocked) == 0:
         print("\t\tNone")
     else:
-        for entry in list_site_blocked:
+        for match_sequence_number, website in enumerate(list_site_blocked):
+            sequenced_entry_date = "".join(
+                [entry_date, "-", str(match_sequence_number)]
+            )
             print(f"\t\t{str(list_site_blocked)}")
-            blocked_sites.update({entry_date: entry})
+            blocked_sites.update({sequenced_entry_date: website})
 
     return blocked_sites
 
@@ -88,7 +96,8 @@ def find_unknown_macs(entries, entry_date):
             print(mac_addresses_given_ip)
     # check if the mac addresses in the entries are in the recognized list
     print("\n\tNow checking MAC addresses that requested DHCP IP...")
-    for address in mac_addresses_given_ip:
+    for match_sequence_number, address in enumerate(mac_addresses_given_ip):
+        sequenced_entry_date = "".join([entry_date, "-", str(match_sequence_number)])
         if address in recognizedmacs.recognizedmacaddresses:
             print(
                 "\t\tRecognized "
@@ -98,6 +107,6 @@ def find_unknown_macs(entries, entry_date):
             )
         else:
             print("\t\t!! Did not recognize " + address)
-            unknown_macs.update({entry_date: address})
+            unknown_macs.update({sequenced_entry_date: address})
 
     return unknown_macs

--- a/router_log_analyzer/recognizedmacs.py
+++ b/router_log_analyzer/recognizedmacs.py
@@ -3,7 +3,6 @@ Listing of recognized MAC addresses.
     MAC addresses here are fake.
 """
 
-
 recognizedmacaddresses = dict(
     [
         ("AA:66:FF:B6:99:72", "Other Device"),

--- a/tests/log_samples/sample_input_file_01.eml
+++ b/tests/log_samples/sample_input_file_01.eml
@@ -45,6 +45,7 @@ Return-Path: <none@none.com>
 [DHCP IP: (10.0.0.5)] to MAC address 55:CC:EA:DF:DD:AA, Sunday, Oct 27,2024 12:47:21
 [WLAN access rejected: incorrect security] from MAC 55:CC:EA:DF:DD:AA, Sunday, Oct 27,2024 12:47:10
 [Admin login] from source 10.0.0.8, Sunday, Oct 27,2024 12:37:41
+[Site blocked: www.anotherwebsite.com] from MAC Address 00:A0:00:EE:CF:00, Sunday, Oct 27,2024 12:18:00
 [Access Control] Device TV with MAC address 00:18:22:8D:BB:A4 is allowed to access the network. Sunday, Oct 27,2024 12:30:23
 [Access Control] Device DESKTOP with MAC address 44:33:11:99:99:66 is allowed to access the network. Sunday, Oct 27,2024 12:30:23
 [Admin login] from source 10.0.0.8, Sunday, Oct 27,2024 12:29:57


### PR DESCRIPTION
Fix the defect reported in #1.  

The functions find_lan_access_rejected, find_site_blocked, find_unknown_macs return one value in the dictionary when more than one match occurs in a single log file. The file date is passed and since this is the same for all entries in a log file, any subsequent matches overwrite the value with same key.